### PR TITLE
Fixed label API reference on Grid Columns

### DIFF
--- a/src/pages/services/aem-cf-console-admin/api/grid-columns/index.md
+++ b/src/pages/services/aem-cf-console-admin/api/grid-columns/index.md
@@ -40,7 +40,7 @@ const guestConnection = await register({
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | key | `string` | ✔️      | Key of the column, must be unique between all extensions |
-| labelMessage | `string` | ✔️ | Label of the column as seen by the user |
+| label | `string` | ✔️ | Label of the column as seen by the user |
 | sortable | `boolean` |  | Wether the column is sortable or not |
 | defaultSortOrder | `ascending`, `descending` | Default order in which to sort the column |
 | render | `function` | | Function that will be used to render the column |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


Docs state the key for the column label is `labelMessage`. The correct key is `label`. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
