### PR TITLE
Fixed side navigation between extensible services

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -95,11 +95,9 @@ module.exports = {
         title: "Publish and Manage the UI Extensions",
         path: "/guides/publication/"
       },
-      // Services
       {
-        title: "Extensible Services",
-        path: "/services/",
-        header: true
+        title: "AEM Content Fragments Console",
+        path: "/services/aem-cf-console-admin/"
       },
       {
         title: "Extension Points",
@@ -142,6 +140,10 @@ module.exports = {
       {
         title: "Troubleshooting",
         path: "/services/aem-cf-console-admin/debug/"
+      },
+      {
+        title: "AEM Content Fragments Editor",
+        path: "/services/aem-cf-editor/"
       },
       {
         title: "Extension Points",
@@ -234,6 +236,10 @@ module.exports = {
             path: "/extension-manager/extension-developed-by-adobe/ue-product-picker"
           },
         ]
+      },
+      {
+        title: "Universal Editor",
+        path: "/services/aem-universal-editor/"
       },
       {
         title: "Extension Points",


### PR DESCRIPTION
Fixed side navigation between extensible services

## Description

This PR fixes #90 and makes the navigation using prev/next links at the bottom of the page to be continuous and uninterruptible user journey.

## Related Issue

#90

## Motivation and Context

I am working on Assets View UIX docs and would like to fix the overall navigation flow as a part of my bigger PR
