### PR TITLE
Fixing Event documentation

### DIFF
--- a/src/pages/services/aem-universal-editor/api/events/index.md
+++ b/src/pages/services/aem-universal-editor/api/events/index.md
@@ -1,34 +1,39 @@
 ---
-title: Working with the events - Universal Editor Extensibility
-description: Leveraging universal editor events within your application
+title: Working with Custom Events - Universal Editor Extensibility
+description: Communicating to the Remote Application through Custom Events
 contributors:
   - https://github.com/AdobeDocs/uix
 ---
 
-# Working with Events
+# Working with Custom Events
 
-The Universal Editor sends defined events to remote applications. In case the remote application has no custom event listener for the sent event, a fallback event listener provided by the universal-editor-cors package is executed.
+The Universal Editor sends defined events to the Remote Application, on top of this Custom Event can also be sent directly from the Extension to the Remote Application.
 
-### Working with Events
+### Working with Custom Events
 
-If your business logic requires sending an event to the Universal Editor, you can use the `triggerEvent` method.
-Here's an example of how to dispatch the `aue:ui-viewport-change` event:
+You can send events to the Remote Application using the `triggerEvent` method.
 
 ```js
     useEffect(() => {
         (async () => {
             const guestConnection = await attach({id: extensionId});
             ...
-                   await guestConnection.host.remoteApp.triggerEvent('aue:ui-viewport-change',
-                        'main',
+                   await guestConnection.host.remoteApp.triggerEvent('my-custom-event',
+                        'body',
                         {
-                          details: {
-                            height: 1024,
-                            width: 768,
-                          }
+                          example: 'payload'
                         }
                     );
             ...
         })();
     }, []);
 ```
+
+## API Reference
+
+### TriggerEvent API
+
+| Field    | Type                                                                        | Required | Description                                                                                                                   |
+| eventName | `string` | ✔️ | Name of the event | 
+| selector  | `string` | ✔️ | A valid CSS selector string|
+| payload  | Serializable `object`| An object that, in addition of the properties defined in the Event Constructor |

--- a/src/pages/services/aem-universal-editor/api/events/index.md
+++ b/src/pages/services/aem-universal-editor/api/events/index.md
@@ -1,17 +1,17 @@
 ---
-title: Working with Custom Events - Universal Editor Extensibility
-description: Communicating to the Remote Application through Custom Events
+title: Working with CustomEvent - Universal Editor Extensibility
+description: Communicating to the Remote Application through CustomEvent
 contributors:
   - https://github.com/AdobeDocs/uix
 ---
 
 # Working with Custom Events
 
-The Universal Editor sends defined events to the Remote Application, on top of this Custom Event can also be sent directly from the Extension to the Remote Application.
+The Universal Editor sends defined events to the remote application, on top of this `CustomEvent` can also be sent directly from the Extension to the remote application.
 
 ### Working with Custom Events
 
-You can send events to the Remote Application using the `triggerEvent` method.
+You can send events to the remote application using the `triggerEvent` method.
 
 ```js
     useEffect(() => {


### PR DESCRIPTION
Rewrite of the Universal Editor Documentation

## Description

Fixing major misunderstandings in the description and example of the Universal Editor event documentation.

