### PR TITLE
Generalized Extension Manager docs

### DIFF
--- a/src/pages/extension-manager/feature-highlights/index.md
+++ b/src/pages/extension-manager/feature-highlights/index.md
@@ -113,7 +113,7 @@ This process allows you to fine-tune your extension settings without the hassle 
 [Extension Manager](https://experience.adobe.com/aem/extension-manager) provides a safe playground to preview extensions before enabling them for the entire environment and the ability to easily share these previews.
 
 ### Preview Extensions
-To preview extensions without installing them, simply click the preview icon found in the `Action` column. This action will open the Content Fragment Console, allowing you to explore the extension within the selected environment.
+To preview extensions in a preproduction environment without installing them, simply click the preview icon found in the `Action` column. This action will open the corresponding application like Content Fragment Console or AEM Assets View, allowing you to explore the extension within the selected environment.
 ![Preview extension](preview.png)
 
 ### Share with Teammates

--- a/src/pages/extension-manager/index.md
+++ b/src/pages/extension-manager/index.md
@@ -1,15 +1,15 @@
 ---
-title: Extension Manager in AEM Sites
+title: Extension Manager in AEM Experience Manager
 description: Explore, enable and configure UI Extensions
 contributors:
   - AdobeDocs/uix
 ---
-# Extension Manager in AEM Sites
-Extension Manager in AEM Sites is a surface, designed for practitioners and developers seeking creative freedom within AEM. Within Extension Manager, you can enable or disable extensions on a per-instance basis, access Adobe's first-party extensions, and much more.
+# Extension Manager in AEM Experience Manager
+Extension Manager in AEM Experience Manager is a surface, designed for practitioners and developers seeking creative freedom within AEM. Within Extension Manager, you can enable or disable extensions on a per-instance basis, access Adobe's first-party extensions, and much more.
 
 This guide will walk you through the initial steps to get started with Extension Manager. You will learn how to access the Extension Manager page and understand the role-based permissions to ensure a smooth start.
 
-## Accessing Extension Manager in AEM Sites
+## Accessing Extension Manager in AEM Experience Manager
 To access Extension Manager, follow these steps:
 
 1. **URL**: Open your web browser and navigate to the https://experience.adobe.com/aem/extension-manager 


### PR DESCRIPTION
Updated Extension Manager documentation to make it less focused on AEM Sites due to the recent implementation of Assets UI extensibility.

## Description

1. Made documentation less focused on the AEM Sites
2. Clarified that the preview feature is available only in preprod envs

## Related Issue

N/A

## Motivation and Context

Align Extension Manager positioning with the actual state of things, support AEM Assets View extensibility
