### PR TITLE
Update index.md to add details for mimetype and remove preferredRendi…

### DIFF
--- a/src/pages/extension-manager/extension-developed-by-adobe/configurable-asset-picker/index.md
+++ b/src/pages/extension-manager/extension-developed-by-adobe/configurable-asset-picker/index.md
@@ -19,7 +19,7 @@ The extension will enable you to list the repositories your authors will be able
 
 Configuration also supports following types of filters:
 - File type (Images, Video etc.)
-- Repository type(author, delivery)
+- Repository type (author, delivery)
 
 ## Configuration in Edge Delivery Site
 
@@ -59,7 +59,7 @@ Adding a component for author in crosswalk site is like adding any other custom 
 - `id`: can be any value.
 - `Image component`: must have `custom-asset-namespace:custom-asset` value, because it has been overridden in the extension to display customized asset selector popup.
 - `configUrl`: points to JSON configuration file, can be hosted anywhere you prefer. Must be accessible to the extension, which runs in author's web browser. Extension will fetch this JSON file and configure asset picker for this component accordingly.
-- `imageMimeType component`: Optional `custom-asset-namespace:custom-asset-mimetype` value, it has been overridden in the extension to contain selected asset MIME Type. Please note that if mime type is set to image/* or for relative paths that resolve to an asset in AEM and is known to be an image, the asset is rendered using edge delivery services. In case you require the asset to be rendered using Dynamic Media with OpenAPI capabilities[https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/dynamic-media-open-apis/dynamic-media-open-apis-overview], select the asset from delivery repository and make sure the imageMimeType is not present in the model.
+- `imageMimeType component`: Optional `custom-asset-namespace:custom-asset-mimetype` value, it has been overridden in the extension to contain selected asset MIME Type. Please note that if mime type is set to image/* or for relative paths that resolve to an asset in AEM and is known to be an image, the asset is rendered using edge delivery services. In case you require the asset to be rendered using [Dynamic Media with OpenAPI capabilities] (https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/dynamic-media-open-apis/dynamic-media-open-apis-overview), select the asset from delivery repository and make sure the imageMimeType is not present in the model.
 - `Alt-Text component`: Optional, it's like any other additional component you may want to add.
 
 This model is necessary for custom asset picker to show up when user clicks on its option it in properties panel.

--- a/src/pages/extension-manager/extension-developed-by-adobe/configurable-asset-picker/index.md
+++ b/src/pages/extension-manager/extension-developed-by-adobe/configurable-asset-picker/index.md
@@ -8,7 +8,7 @@ contributors:
 # Universal Editor Custom Asset Picker
 
 This extension allows creating a configurable, custom asset picker for Universal Editor that is tailored to your need by simply providing a JSON configuration file. Relevant crosswalk project needs to follow certain guidelines.
-It's useful in case where we want to enable authors to select assets of certain file types, image sizes, only from specified repositories etc.
+It's useful in case where we want to enable authors to select assets of certain file types only from specified repositories etc.
 
 ## Extension Overview
 ![Asset picker](asset-picker-extension.gif)
@@ -19,7 +19,7 @@ The extension will enable you to list the repositories your authors will be able
 
 Configuration also supports following types of filters:
 - File type (Images, Video etc.)
-- Asset size (height, width)
+- Repository type(author, delivery)
 
 ## Configuration in Edge Delivery Site
 
@@ -59,7 +59,7 @@ Adding a component for author in crosswalk site is like adding any other custom 
 - `id`: can be any value.
 - `Image component`: must have `custom-asset-namespace:custom-asset` value, because it has been overridden in the extension to display customized asset selector popup.
 - `configUrl`: points to JSON configuration file, can be hosted anywhere you prefer. Must be accessible to the extension, which runs in author's web browser. Extension will fetch this JSON file and configure asset picker for this component accordingly.
-- `imageMimeType component`: must have `custom-asset-namespace:custom-asset-mimetype` value, because it has been overridden in the extension to contain selected asset MIME Type.
+- `imageMimeType component`: Optional `custom-asset-namespace:custom-asset-mimetype` value, it has been overridden in the extension to contain selected asset MIME Type. Please note that if mime type is set to image/* or for relative paths that resolve to an asset in AEM and is known to be an image, the asset is rendered using edge delivery services. In case you require the asset to be rendered using Dynamic Media with OpenAPI capabilities[https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/dynamic-media-open-apis/dynamic-media-open-apis-overview], select the asset from delivery repository and make sure the imageMimeType is not present in the model.
 - `Alt-Text component`: Optional, it's like any other additional component you may want to add.
 
 This model is necessary for custom asset picker to show up when user clicks on its option it in properties panel.
@@ -132,12 +132,10 @@ This is sample asset picker configuration file that allows filtering assets by i
       "author-p7452-e733061.adobeaemcloud.com",
       "delivery-p130360-e1272151.adobeaemcloud.com",
     ],
-    "preferredDimensions":{
-        "minWidth": 500,
-        "maxWidth": 2000, 
-        "minHeight": 500,
-        "maxHeight": 2000
-    },
+   "aemTierType": [
+        "delivery",
+        "author"
+    ],
     "filterSchema": [
         {
             "fields": [


### PR DESCRIPTION
…tions

<!--- Provide a general summary of your changes in the Title above -->

## Description

PreferredRenditions config does not serve any purpose and we need to stop supoorting it in future versions of the extension, hence removing from the docs

MimeType changes: Mime type is optional. Presence of mime type decides whether the asset would be served from native eds delivery or Dynamic media.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There has been a lot of confusion over using delivery assets in eds pages. The documentation mentions the mimetype as mandatory and when this property is added to the model, asset is served from media bus and hence developers are confused on how to use DM delivery  to serve the assets