### PR TITLE
Added common Theme API to the Assets View UI Extensibility docs

### DIFF
--- a/src/pages/services/aem-assets-view/api/commons/index.md
+++ b/src/pages/services/aem-assets-view/api/commons/index.md
@@ -196,3 +196,19 @@ This API provides methods to support localization of the UI Extension.
 ```js
 const { locale } = await guestConnection.host.i18n.getLocalizationInfo();
 ```
+
+### Theme API
+
+This API provides methods to retrieve the current host application color scheme. 
+
+`theme.getThemeInfo()`
+
+**Description:** returns information about the current color scheme used in the AEM Assets View.
+
+**Return Object Structure**
+- `colorScheme` (`string`): The current color scheme locale used in the AEM Assets View, either `light` or `dark`.
+
+**Example:**
+```js
+const { colorScheme } = await guestConnection.host.theme.getThemeInfo();
+```


### PR DESCRIPTION
Added common Theme API to the Assets View UI Extensibility docs

## Description

The "common host API" section of the Assets View UI extensibility got new "Theme API" section added with the method that  returns the current color scheme.

## Related Issue

n/a

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Make the API docs more complete and in line with implementation

<!--- Why is this change required? What problem does it solve? -->
