### PR TITLE
Fixed GetAccess link for CF Admin and Assets View

### DIFF
--- a/src/pages/services/aem-assets-view/extension-development/index.md
+++ b/src/pages/services/aem-assets-view/extension-development/index.md
@@ -23,7 +23,7 @@ UI Extensions, as with any App Builder application, are represented as projects 
 
 <InlineAlert slots="text" />
 
-If you don't have access to the Adobe Developer Console, refer to the [How to Get Access](../get-access) guide for instructions.
+If you don't have access to the Adobe Developer Console, refer to the [How to Get Access](../../../guides/get-access) guide for instructions.
 
 To begin, we need to create a new Project which will supply us with the configuration and resources.
 

--- a/src/pages/services/aem-cf-console-admin/extension-development/index.md
+++ b/src/pages/services/aem-cf-console-admin/extension-development/index.md
@@ -32,7 +32,7 @@ UI Extensions, as with any App Builder application, are represented as projects 
 
 <InlineAlert slots="text" />
 
-If you don't have access to the Adobe Developer Console, refer to the [How to Get Access](../get-access) guide for instructions.
+If you don't have access to the Adobe Developer Console, refer to the [How to Get Access](../../../guides/get-access) guide for instructions.
 
 To begin, we need to create a new Project which will supply us with the configuration and resources.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed GetAccess link for CF Admin and Assets View

## Related Issue

Today, "Getting access to Developer Console" link is broken (results in 404) for the CF Admin and Assets View.

Steps:
1. Go to
https://developer.adobe.com/uix/docs/services/aem-cf-console-admin/extension-development/#create-a-project-in-adobe-developer-console
or
https://developer.adobe.com/uix/docs/services/aem-assets-view/extension-development/#create-a-project-in-adobe-developer-console

2. Click "Get Access"

Result: 404

## Motivation and Context

n/a
