### PR TITLE
Update docs to indicate how to select a template

### DIFF
--- a/src/pages/services/aem-assets-view/code-generation/index.md
+++ b/src/pages/services/aem-assets-view/code-generation/index.md
@@ -62,7 +62,7 @@ Create a directory and run the following commands from that directory:
       Only Templates Supported By My Org
     ```
 
-4. Select the template named `@adobe/aem-assets-details-ext-tpl` (Template for an AIO CLI App Builder plugin that generates code for a UI extension in the Asset Details section of the AEM Assets View).
+4. Use the spacebar to select the template named `@adobe/aem-assets-details-ext-tpl` (Template for an AIO CLI App Builder plugin that generates code for a UI extension in the Asset Details section of the AEM Assets View).
 
     ```shell
     ➜  demo-extension-project % aio app init

--- a/src/pages/services/aem-cf-console-admin/code-generation/index.md
+++ b/src/pages/services/aem-cf-console-admin/code-generation/index.md
@@ -60,7 +60,7 @@ Create a directory and run the following commands from that directory:
       Only Templates Supported By My Org
     ```
 
-4. Select the template named @adobe/aem-cf-admin-ui-ext-tpl (Extensibility template for AEM Content Fragment Admin Console).
+4. Use the spacebar to select the template named @adobe/aem-cf-admin-ui-ext-tpl (Extensibility template for AEM Content Fragment Admin Console).
 
     ```shell
     ➜  demo-extension-project % aio app init


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Going thru the guides for the first time, it was not clear to me how to select a template. I used arrows keys so the CLI cursor pointed at the template, but I did not press spacebar to actually make the selection. Spacebar is not mentioned in the docs or in the CLI (as far as I could tell). Since I had the issue perhaps other might as well. This small change could help avoid it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
