### PR TITLE
RTE Toolbar extension also support insertContent instructions

### DIFF
--- a/src/pages/services/aem-cf-editor/api/rte-toolbar/index.md
+++ b/src/pages/services/aem-cf-editor/api/rte-toolbar/index.md
@@ -62,6 +62,7 @@ Extension as well may control availability of standard RTE buttons.
 | Instruction | Value |  Description |
 | ----- | ---- | ----------- |
 | `replaceContent` | `string` | Replaces current editor content with a content provided in `value` property |
+| `insertContent` | `string` | Inserts a content provided in `value` property in current carret position |
 
 ## Standard buttons
 


### PR DESCRIPTION
`insertContent` instruction is supported by RTE Toolbar extension as much as Widgets and Badges

## Description



## Related Issue

No issues

## Motivation and Context

A customer asked to have the cursor position as part of the `state` object because he wasn't aware of the insertContent capability
