### PR TITLE
Correct getApiKey in docs

### DIFF
--- a/src/pages/services/aem-assets-view/api/commons/index.md
+++ b/src/pages/services/aem-assets-view/api/commons/index.md
@@ -129,7 +129,7 @@ The API uses `auth` namespace.
 - `imsOrgName` (`string`): The name of the IMS organization.
 - `accessToken` (`string`): The access token for the IMS.
 
-`auth.()`
+`auth.getApiKey()`
 
 **Description:** returns API key used by the AEM Assets View.
 

--- a/src/pages/services/aem-assets-view/api/commons/index.md
+++ b/src/pages/services/aem-assets-view/api/commons/index.md
@@ -129,7 +129,7 @@ The API uses `auth` namespace.
 - `imsOrgName` (`string`): The name of the IMS organization.
 - `accessToken` (`string`): The access token for the IMS.
 
-`auth.getApiKey()`
+`auth.()`
 
 **Description:** returns API key used by the AEM Assets View.
 
@@ -139,7 +139,7 @@ The API uses `auth` namespace.
 ```js
 const { imsOrg, accessToken } = await guestConnection.host.auth.getIMSInfo();
 
-const apiKey = await guestConnection.host.auth.getAPIKey();
+const apiKey = await guestConnection.host.auth.getApiKey();
 ```
 
 ### Discovery API


### PR DESCRIPTION
Corrected code example to use getApiKey (not getAPIKey)

<!--- Provide a general summary of your changes in the Title above -->

## Description

The docs has an example usage of getApiKey, but uses getAPIKey 

## Related Issue

https://github.com/AdobeDocs/uix/issues/128

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

corrects the typo
