### PR TITLE
Update docs for header menu button phase 2 (only merge after GA)

### DIFF
--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -40,7 +40,7 @@ Extensions should use the `aem/assets/browse/1` extension point to utilize exten
 
 An extension needs to implement both `actionBar` and `quickActions` namespace to be recognized by Assets View.
 The `headerMenu` namespace is optional for browse extensions.
-If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
+If you implement `headerMenu`, all of its methods are optional: `getButtons`, `getHiddenButtonIds`, and `overrideButton`. Implement only the methods your extension needs.
 
 ## Custom ActionBar actions and QuickActions menu actions
 
@@ -287,11 +287,12 @@ overrideBuiltInAction: ({ actionId, context, resource }) => {
 
 The `headerMenu` namespace supports adding custom header menu buttons in the browse view header menu and optionally hiding and overriding built-in header menu buttons.
 
-If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
+All `headerMenu` methods are optional:
 
-- `getButtons({ context, resource })` — **required** when `headerMenu` is present
-- `getHiddenHeaderButtonIds({ context, resource })` — optional
-- `overrideHeaderMenuButton({ buttonId, context, resource })` — optional
+- `getButtons({ context, resource })` — optional
+- `getHiddenButtonIds({ context, resource })` — optional
+- `overrideButton({ buttonId, context, resource })` — optional
+
 
 `getButtons({ context, resource })`
 
@@ -344,7 +345,7 @@ headerMenu: {
 },
 ```
 
-`getHiddenHeaderButtonIds({ context, resource })`
+`getHiddenButtonIds({ context, resource })`
 
 **Description:** Returns an array of [built-in header menu button ids](#built-in-header-menu-buttons) that should be hidden.
 
@@ -359,7 +360,7 @@ The host calls this method when the browse location or context changes. Extensio
 **Example:**
 
 ```js
-getHiddenHeaderButtonIds: ({ context, resource }) => {
+getHiddenButtonIds: ({ context, resource }) => {
   if (context === 'assets') {
     return ['createFolder'];
   }
@@ -367,7 +368,7 @@ getHiddenHeaderButtonIds: ({ context, resource }) => {
 },
 ```
 
-`overrideHeaderMenuButton({ buttonId, context, resource })`
+`overrideButton({ buttonId, context, resource })`
 
 **Description:** Return `true` if the extension handled the click and the built-in header menu button handler should **not** run. Return `false` to let the Host run the default behavior.
 
@@ -381,7 +382,7 @@ getHiddenHeaderButtonIds: ({ context, resource }) => {
 **Example:**
 
 ```js
-overrideHeaderMenuButton: ({ buttonId, context, resource }) => {
+overrideButton: ({ buttonId, context, resource }) => {
   if (buttonId === 'addAssets') {
     // Custom handling; skip built-in handler
     return true;
@@ -403,7 +404,7 @@ provided by the `@adobe/uix-guest` library.
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares
 that the extension uses the `actionBar` and `quickActions` namespaces with their required methods, and may include the
-optional `headerMenu` namespace. For `headerMenu`, only `getButtons` is required; other `headerMenu` methods are optional.
+optional `headerMenu` namespace. All `headerMenu` methods are optional; implement `getButtons`, `getHiddenButtonIds`, and/or `overrideButton` as needed.
 
 This example demonstrates the minimal set of namespaces and methods required for a browse extension to be recognized
 by the Host application.
@@ -434,8 +435,14 @@ function ExtensionRegistration() {
                     },
                 },
                 headerMenu: {
-                    async getButtons ({ context, resource }) {
-                        return []
+                    async getButtons({ context, resource }) {
+                        return [];
+                    },
+                    async getHiddenButtonIds({ context, resource }) {
+                        return [];
+                    },
+                    async overrideButton({ buttonId, context, resource }) {
+                        return false;
                     },
                 },
             },
@@ -698,11 +705,14 @@ function ExtensionRegistration() {
                     async getButtons({ context, resource }) {
                         return [];
                     },
-                    async getHiddenHeaderButtonIds({ context, resource }) {
+                    async getHiddenButtonIds({ context, resource }) {
                         if (context === 'assets') {
                             return ['createFolder'];
                         }
                         return [];
+                    },
+                    async overrideButton({ buttonId, context, resource }) {
+                        return false;
                     },
                 },
             },
@@ -737,7 +747,10 @@ function ExtensionRegistration() {
                     async getButtons({ context, resource }) {
                         return [];
                     },
-                    async overrideHeaderMenuButton({ buttonId, context, resource }) {
+                    async getHiddenButtonIds({ context, resource }) {
+                        return [];
+                    },
+                    async overrideButton({ buttonId, context, resource }) {
                         if (buttonId === 'addAssets') {
                             // Custom upload or validation flow
                             return true;

--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -8,6 +8,7 @@ contributors:
 # Browse View
 
 AEM Assets View offers the ability to customize the ActionBar, QuickActions and HeaderMenu in the Browse View.
+Extensions can add, hide, and remove **header buttons** in the top header: add custom header buttons, hide built-in header buttons (removing them from the header), and override built-in header button clicks so the default handler does not run.
 
 <InlineAlert variant="info" slots="text" />
 
@@ -32,12 +33,14 @@ Browse View are selected.
 **QuickActions** is the dropdown menu from the More action button (shown as `⋯`) next to each asset.
 ![quick actions](quick-actions.png)
 
-**HeaderMenu** is the set of buttons at the top right of the browse screen. Custom buttons may be added between the ellipses menu and default HeaderMenu buttons. 
+**HeaderMenu** is the set of **header buttons** at the top right of the browse screen. Custom header buttons may be added between the ellipses menu and default HeaderMenu buttons.
 ![header buttons](header-menu.png)
 
 Extensions should use the `aem/assets/browse/1` extension point to utilize extensibility services of the Browse View.
 
-An extension needs to implement both `actionBar` and `quickActions` namespace to be recognized by Assets View. Extensions may optionally implement the `headerMenu` namespace.
+An extension needs to implement both `actionBar` and `quickActions` namespace to be recognized by Assets View.
+The `headerMenu` namespace is optional for browse extensions.
+If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
 
 ## Custom ActionBar actions and QuickActions menu actions
 
@@ -55,9 +58,9 @@ Using the [`quickActions`](#quickactions-namespace) namespace, built-in QuickAct
 selected asset.
 
 ## Custom HeaderMenu buttons 
-This extensibility feature allows context-aware customization of the HeaderMenu buttons.
+This extensibility feature allows context-aware customization of header buttons in the HeaderMenu.
 
-Using the [`headerMenu`](#headermenu-namespace) namespace, custom buttons could be added to the HeaderMenu before the list of built-in buttons based on the context.
+Using the [`headerMenu`](#headermenu-namespace) namespace, you can add custom header buttons before built-in header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not or is run conditionally.
 
 In this example, a custom button is added to the HeaderMenu before the list of built-in HeaderMenu buttons.
 
@@ -102,6 +105,23 @@ action ids of actions that can be hidden:
 | `search` | "edit", "openInExpress", "reprocess", "copy", "move", "rename", "bulkRename", "managePermissions", "delete", "publish", "download", "share" |
 | `trash` | "delete" |
 
+#### Built-in header buttons
+
+Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar (not ActionBar actions).
+Depending on context and extension point, the host exposes the following built-in header **button** ids that can be hidden or overridden.
+
+| Context | Extension point | Header button IDs |
+|------------|------------|------------|
+| `assets` | `aem/assets/browse/1` | `createFolder`, `addAssets` |
+| `collections` | `aem/assets/browse/1` | `createCollection`, `addToCollection`, `editSmartCollection` |
+| `recent` | `aem/assets/browse/1` | — |
+| `search` | `aem/assets/browse/1` | — |
+| `trash` | `aem/assets/browse/1` | — |
+| `details` | `aem/assets/details/1` | `assignTasks`, `download` |
+
+The `details` row applies to the [Details View](../details-view/index.md) extension point only; browse extensions do not receive those built-in header buttons.
+In `recent`, `search`, and `trash`, there are no built-in header buttons to hide, but extensions can still add custom header buttons via [`getButtons`](#headermenu-namespace).
+
 ### Extension API Reference
 
 The extension definition object passed by the extension to the `register()` function defines the [`actionBar`](#actionbar-namespace), [`quickActions`](#quickActions-namespace) and [`headerMenu`](#headermenu-namespace) namespaces.
@@ -109,7 +129,7 @@ The extension definition object passed by the extension to the `register()` func
 The methods in these namespaces provide the capabilities to
 - Add custom actions to the ActionBar
 - Hide or customize built-in actions in the ActionBar and QuickActions
-- Add custom buttons to the HeaderMenu
+- Add custom header buttons to the HeaderMenu, and optionally hide or override built-in header buttons
 
 
 
@@ -184,12 +204,11 @@ getHiddenBuiltInActions: ({ context, resourceSelection }) => {
 
 `overrideBuiltInAction({ actionId, context, resourceSelection })`
 
-**Description:**  Return true to indicate the Host should perform the built-in action, false otherwise. 
+**Description:** Return `true` if the extension handled the action and the built-in handler should **not** run (the action is overridden). Return `false` to let the Host run the default built-in action.
 
 This method is called by the Host when the user activates one of the built-in actions, before invoking the actual action
-handler. The method returns true if the Extension had performed custom action processing and the Host should not invoke
-built-in action handler. Otherwise the method call returns false, to indicate that the Extension
-had ignored the invocation and the Host should use built-in action handler.
+handler. The method returns `true` if the Extension had performed custom action processing and the Host should not invoke
+the built-in action handler. Otherwise the method returns `false`, and the Host should use the built-in action handler.
 
 **Parameters:**
 - actionId (`string`): [built-in action id](#built-in-actions).
@@ -243,12 +262,11 @@ getHiddenBuiltInActions: ({ context, resource }) => {
 
 `overrideBuiltInAction: ({ actionId, context, resource })`
 
-**Description:**  
+**Description:** Return `true` if the extension handled the action and the built-in handler should **not** run. Return `false` to let the Host run the default built-in action.
 
 This method is called by the Host when the user activates one of the built-in actions, before invoking the actual action
-handler. The method returns true if the Extension had performed custom action processing and the Host should not invoke
-built-in action handler. Otherwise the method call returns false, to indicate that the Extension
-had ignored the invocation and the Host should use built-in action handler.
+handler. The method returns `true` if the Extension had performed custom action processing and the Host should not invoke
+the built-in action handler. Otherwise the method returns `false`, and the Host should use the built-in action handler.
 
 **Parameters:**
 - actionId (`string`): [built-in action id](#built-in-actions).
@@ -268,10 +286,16 @@ overrideBuiltInAction: ({ actionId, context, resource }) => {
 ```
 
 #### headerMenu namespace
-The `headerMenu` namespace currently has the following method
-- `getButtons({context, resource})`
 
-`getButtons({context, resource})`
+The `headerMenu` namespace supports custom **header buttons** in the browse header and optional customization of built-in header buttons.
+
+If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
+
+- `getButtons({ context, resource })` — **required** when `headerMenu` is present
+- `getHiddenHeaderButtonIds({ context, resource })` — optional
+- `overrideHeaderMenuButton({ buttonId, context, resource })` — optional
+
+`getButtons({ context, resource })`
 
 **Description:** Returns an array of custom header button definitions that will be added to the application's header menu. These buttons are rendered alongside built-in header buttons and provide a way for extensions to add custom functionality accessible from the top header area on browse screens.
 
@@ -282,64 +306,106 @@ The `headerMenu` namespace currently has the following method
   - path (`string`): The path of the current location
   - In contexts that do not support a notion of active resource, like `'trash'`, `'search'` or `'recent'`, the `resource` argument will be `undefined`.
     For `'assets'` and `'collections'` context, the `resource` is a JSON object with `id` and `path`, even for the root folder.
-  
 
-**Returns:** (`array`) - An array of button configuration objects, where each object contains:
+**Returns:** (`array`) An array of button configuration objects, where each object contains:
 - id (`string`): Unique identifier for the button within the extension
 - label (`string`): Display text for the button
 - icon (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons)
-- onClick (`function`): Callback function executed when button is clicked, receives `{context, resource}` as parameter
+- onClick (`function`): Callback function executed when the header button is clicked; receives `{ context, resource }`
 - variant (`string`, optional): Button visual style, defaults to `'primary'`
   - Supported values: `'accent'`, `'primary'`, `'secondary'`, `'negative'`
 
 **Example:**
 
 ```javascript
-// Extension implementation
-const headerMenuAPI = {
+headerMenu: {
   async getButtons({ context, resource }) {
-    // Only show buttons in assets context
     if (context !== 'assets') {
       return [];
     }
-    // adds 2 custom buttons to the application header menu
     return [
       {
         id: 'export-metadata',
         label: 'Export Metadata',
-        icon: 'Download', // React Spectrum Workflow icon name
+        icon: 'Download',
         variant: 'secondary',
         onClick: async ({ context, resource }) => {
-          console.log('Exporting metadata for:', resource);
-          // Custom export logic here
-        }
+          // Custom logic
+        },
       },
       {
         id: 'custom-workflow',
         label: 'Start Workflow',
         icon: 'Workflow',
         onClick: async ({ context, resource }) => {
-          // Custom workflow logic here
-        }
-      }
+          // Custom logic
+        },
+      },
     ];
+  },
+},
+```
+
+`getHiddenHeaderButtonIds({ context, resource })`
+
+**Description:** Returns an array of [built-in header button ids](#built-in-header-buttons) that should be hidden.
+
+The host calls this method when the browse location or context changes. Extension code should return quickly; avoid slow or blocking work (for example backend calls), because the host may wait on the result before rendering header buttons.
+
+**Parameters:**
+- context (`string`): current [browsing context](#browsing-context).
+- resource (`object`): Same semantics as for [`getButtons`](#headermenu-namespace).
+
+**Returns:** (`array`) An array of built-in header button ids to hide, or an empty array if none should be hidden.
+
+**Example:**
+
+```js
+getHiddenHeaderButtonIds: ({ context, resource }) => {
+  if (context === 'assets') {
+    return ['createFolder'];
   }
-};
+  return [];
+},
+```
+
+`overrideHeaderMenuButton({ buttonId, context, resource })`
+
+**Description:** Return `true` if the extension handled the click and the built-in header button handler should **not** run. Return `false` to let the Host run the default behavior.
+
+**Parameters:**
+- buttonId (`string`): Built-in header button id from [Built-in header buttons](#built-in-header-buttons).
+- context (`string`): current [browsing context](#browsing-context).
+- resource (`object`): Same semantics as for [`getButtons`](#headermenu-namespace).
+
+**Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
+
+**Example:**
+
+```js
+overrideHeaderMenuButton: ({ buttonId, context, resource }) => {
+  if (buttonId === 'addAssets') {
+    // Custom handling; skip built-in handler
+    return true;
+  }
+  return false;
+},
 ```
 
 
 ## Examples
 
-These code snippets demonstrate how to add a custom action to the ActionBar, add buttons to the HeaderMenu,
-hide built-in actions or override the
-built-in action handlers from the ActionBar and QuickActions menu in the Browse View. (The examples below serve
-illustrative purposes thus omit certain import statements and other non-important parts.)
+These code snippets demonstrate how to add a custom action to the ActionBar, add header buttons to the HeaderMenu,
+hide built-in actions or override built-in action handlers from the ActionBar and QuickActions menu, and optionally
+hide or override built-in header buttons in the Browse View. (The examples below serve illustrative purposes thus omit
+certain import statements and other non-important parts.)
 
 The ExtensionRegistration component initializes the extension registration process by calling the `register()` function
 provided by the `@adobe/uix-guest` library.
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares
-that the extension uses the `actionBar`, `quickActions` and `headerMenu` namespaces and declares required methods for these namespaces.
+that the extension uses the `actionBar` and `quickActions` namespaces with their required methods, and may include the
+optional `headerMenu` namespace. For `headerMenu`, only `getButtons` is required; other `headerMenu` methods are optional.
 
 This example demonstrates the minimal set of namespaces and methods required for a browse extension to be recognized
 by the Host application.
@@ -614,6 +680,84 @@ function ExtensionRegistration() {
 }
 ```
 
-To open a custom dialog from custom ActionBar actions, QuickActions menu actions or HeaderMenu, refer to the
+### Example of hiding built-in header buttons
+
+In this example, the built-in **Create folder** header button (`createFolder`) is hidden in the `assets` context.
+
+```js
+function ExtensionRegistration() {
+    const init = async () => {
+        const guestConnection = await register({
+            id: extensionId,
+            methods: {
+                actionBar: {
+                    // ...
+                },
+                quickActions: {
+                    // ...
+                },
+                headerMenu: {
+                    async getButtons({ context, resource }) {
+                        return [];
+                    },
+                    async getHiddenHeaderButtonIds({ context, resource }) {
+                        if (context === 'assets') {
+                            return ['createFolder'];
+                        }
+                        return [];
+                    },
+                },
+            },
+        });
+    };
+    init().catch(console.error);
+
+    return <Text>IFrame for integration with Host (AEM Assets View)...</Text>;
+}
+
+export default ExtensionRegistration;
+```
+
+### Example of overriding a built-in header button
+
+In this example, when the user activates the **Add assets** header button (`addAssets`), the extension runs custom logic
+and skips the Host's default handler by returning `true`.
+
+```js
+function ExtensionRegistration() {
+    const init = async () => {
+        const guestConnection = await register({
+            id: extensionId,
+            methods: {
+                actionBar: {
+                    // ...
+                },
+                quickActions: {
+                    // ...
+                },
+                headerMenu: {
+                    async getButtons({ context, resource }) {
+                        return [];
+                    },
+                    async overrideHeaderMenuButton({ buttonId, context, resource }) {
+                        if (buttonId === 'addAssets') {
+                            // Custom upload or validation flow
+                            return true;
+                        }
+                        return false;
+                    },
+                },
+            },
+        });
+    };
+    init().catch(console.error);
+
+    return <Text>IFrame for integration with Host (AEM Assets View)...</Text>;
+}
+
+export default ExtensionRegistration;
+```
+
+To open a custom dialog from custom ActionBar actions, QuickActions menu actions or HeaderMenu header buttons, refer to the
 [Modal API](../commons/index.md#modal-api) provided by AEM Assets View to all extensions for implementation of
 dialog management.

--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -287,6 +287,8 @@ overrideBuiltInAction: ({ actionId, context, resource }) => {
 
 The `headerMenu` namespace supports adding custom header menu buttons in the browse view header menu and optionally hiding and overriding built-in header menu buttons.
 
+`headerMenu` behavior is shared between Browse View and Details View. If an extension implements `headerMenu` in either `aem/assets/browse/1` or `aem/assets/details/1`, those methods are used for header menu handling in both screens. The built-in button set and button ids still differ by screen/context, so use the appropriate ids from each page's [Built-in header menu buttons](#built-in-header-menu-buttons) table.
+
 All `headerMenu` methods are optional:
 
 - `getButtons({ context, resource })` — optional

--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -8,7 +8,7 @@ contributors:
 # Browse View
 
 AEM Assets View offers the ability to customize the ActionBar, QuickActions and HeaderMenu in the Browse View.
-Extensions can add, hide, and remove **header buttons** in the top header: add custom header buttons, hide built-in header buttons (removing them from the header), and override built-in header button clicks so the default handler does not run.
+
 
 <InlineAlert variant="info" slots="text" />
 
@@ -33,7 +33,7 @@ Browse View are selected.
 **QuickActions** is the dropdown menu from the More action button (shown as `⋯`) next to each asset.
 ![quick actions](quick-actions.png)
 
-**HeaderMenu** is the set of **header buttons** at the top right of the browse screen. Custom header buttons may be added between the ellipses menu and default HeaderMenu buttons.
+**HeaderMenu** is the set of buttons at the top right of the browse screen. Custom header buttons may be added between the ellipses menu and default HeaderMenu buttons.
 ![header buttons](header-menu.png)
 
 Extensions should use the `aem/assets/browse/1` extension point to utilize extensibility services of the Browse View.
@@ -58,9 +58,9 @@ Using the [`quickActions`](#quickactions-namespace) namespace, built-in QuickAct
 selected asset.
 
 ## Custom HeaderMenu buttons 
-This extensibility feature allows context-aware customization of header buttons in the HeaderMenu.
+This extensibility feature allows context-aware customization of the HeaderMenu buttons.
 
-Using the [`headerMenu`](#headermenu-namespace) namespace, you can add custom header buttons before built-in header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not or is run conditionally.
+Using the [`headerMenu`](#headermenu-namespace) namespace, you can add custom header buttons before built-in header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not run or runs conditionally.
 
 In this example, a custom button is added to the HeaderMenu before the list of built-in HeaderMenu buttons.
 
@@ -107,19 +107,17 @@ action ids of actions that can be hidden:
 
 #### Built-in header buttons
 
-Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar (not ActionBar actions).
+Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar.
 Depending on context and extension point, the host exposes the following built-in header **button** ids that can be hidden or overridden.
 
-| Context | Extension point | Header button IDs |
-|------------|------------|------------|
-| `assets` | `aem/assets/browse/1` | `createFolder`, `addAssets` |
-| `collections` | `aem/assets/browse/1` | `createCollection`, `addToCollection`, `editSmartCollection` |
-| `recent` | `aem/assets/browse/1` | — |
-| `search` | `aem/assets/browse/1` | — |
-| `trash` | `aem/assets/browse/1` | — |
-| `details` | `aem/assets/details/1` | `assignTasks`, `download` |
+| Context |  Header button IDs that can be hidden or overridden |
+|------------|------------|
+| `assets` | "createFolder", "addAssets" |
+| `collections` | "createCollection", "addToCollection", "editSmartCollection" |
+| `recent` | — |
+| `search` | — |
+| `trash` | — |
 
-The `details` row applies to the [Details View](../details-view/index.md) extension point only; browse extensions do not receive those built-in header buttons.
 In `recent`, `search`, and `trash`, there are no built-in header buttons to hide, but extensions can still add custom header buttons via [`getButtons`](#headermenu-namespace).
 
 ### Extension API Reference

--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -7,7 +7,7 @@ contributors:
 
 # Browse View
 
-AEM Assets View offers the ability to customize the ActionBar, QuickActions and HeaderMenu in the Browse View.
+AEM Assets View offers the ability to customize the ActionBar, QuickActions, and header menu in the Browse View.
 
 
 <InlineAlert variant="info" slots="text" />
@@ -33,8 +33,8 @@ Browse View are selected.
 **QuickActions** is the dropdown menu from the More action button (shown as `⋯`) next to each asset.
 ![quick actions](quick-actions.png)
 
-**HeaderMenu** is the set of buttons at the top right of the browse screen. Custom header buttons may be added between the ellipses menu and default HeaderMenu buttons.
-![header buttons](header-menu.png)
+**Header menu** is the set of buttons at the top right of the browse screen. Custom buttons may be added to the header menu between the ellipses menu and the default header menu buttons.
+![header menu](header-menu.png)
 
 Extensions should use the `aem/assets/browse/1` extension point to utilize extensibility services of the Browse View.
 
@@ -57,14 +57,14 @@ In this example, a custom action is added to the ActionBar after the list of bui
 Using the [`quickActions`](#quickactions-namespace) namespace, built-in QuickActions menu actions can be overridden or hidden based on the context and the
 selected asset.
 
-## Custom HeaderMenu buttons 
-This extensibility feature allows context-aware customization of the HeaderMenu buttons.
+## Custom header menu buttons
+This extensibility feature allows context-aware customization of the header menu buttons.
 
-Using the [`headerMenu`](#headermenu-namespace) namespace, you can add custom header buttons before built-in header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not run or runs conditionally.
+Using the [`headerMenu`](#headermenu-namespace) namespace, you can add custom header menu buttons before built-in header menu buttons, hide built-in header menu buttons by id (removing them from the header menu), and override built-in header menu button clicks so the default handler does not run or runs conditionally.
 
-In this example, a custom button is added to the HeaderMenu before the list of built-in HeaderMenu buttons.
+In this example, a custom button is added to the header menu before the list of built-in header menu buttons.
 
-![headerMenu buttons](add-custom-action.jpg)
+![header menu buttons](add-custom-action.jpg)
 
 ## API Reference
 
@@ -105,12 +105,12 @@ action ids of actions that can be hidden:
 | `search` | "edit", "openInExpress", "reprocess", "copy", "move", "rename", "bulkRename", "managePermissions", "delete", "publish", "download", "share" |
 | `trash` | "delete" |
 
-#### Built-in header buttons
+#### Built-in header menu buttons
 
-Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header buttons in the top bar.
-Depending on context and extension point, the host exposes the following built-in header button ids that can be hidden or overridden.
+Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header menu buttons in the top bar.
+Depending on context and extension point, the host exposes the following built-in header menu button ids that can be hidden or overridden.
 
-| Context |  Header button IDs that can be hidden or overridden |
+| Context | Header menu button IDs that can be hidden or overridden |
 |------------|------------|
 | `assets` | "createFolder", "addAssets" |
 | `collections` | "createCollection", "addToCollection", "editSmartCollection" |
@@ -118,7 +118,7 @@ Depending on context and extension point, the host exposes the following built-i
 | `search` | — |
 | `trash` | — |
 
-In `recent`, `search`, and `trash`, there are no built-in header buttons to hide, but extensions can still add custom header buttons via [`getButtons`](#headermenu-namespace).
+In `recent`, `search`, and `trash`, there are no built-in header menu buttons to hide, but extensions can still add custom header menu buttons via [`getButtons`](#headermenu-namespace).
 
 ### Extension API Reference
 
@@ -127,7 +127,7 @@ The extension definition object passed by the extension to the `register()` func
 The methods in these namespaces provide the capabilities to
 - Add custom actions to the ActionBar
 - Hide or customize built-in actions in the ActionBar and QuickActions
-- Add custom header buttons to the HeaderMenu, and optionally hide or override built-in header buttons
+- Add custom header menu buttons, and optionally hide or override built-in header menu buttons
 
 
 
@@ -285,7 +285,7 @@ overrideBuiltInAction: ({ actionId, context, resource }) => {
 
 #### headerMenu namespace
 
-The `headerMenu` namespace supports adding custom header buttons in the browse header and optionally hiding and overriding of built-in header buttons.
+The `headerMenu` namespace supports adding custom header menu buttons in the browse view header menu and optionally hiding and overriding built-in header menu buttons.
 
 If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
 
@@ -295,7 +295,7 @@ If you declare `headerMenu`, you **must** implement `getButtons`. You may also i
 
 `getButtons({ context, resource })`
 
-**Description:** Returns an array of custom header button definitions that will be added to the application's header menu. These buttons are rendered alongside built-in header buttons and provide a way for extensions to add custom functionality accessible from the top header area on browse screens.
+**Description:** Returns an array of custom header menu button definitions that will be added to the application's header menu. These buttons are rendered alongside built-in header menu buttons and provide a way for extensions to add custom functionality accessible from the header menu on browse screens.
 
 **Parameters:**
 - context (`string`): current [browsing context](#browsing-context).
@@ -309,7 +309,7 @@ If you declare `headerMenu`, you **must** implement `getButtons`. You may also i
 - id (`string`): Unique identifier for the button within the extension
 - label (`string`): Display text for the button
 - icon (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons)
-- onClick (`function`): Callback function executed when the header button is clicked; receives `{ context, resource }`
+- onClick (`function`): Callback function executed when the header menu button is clicked; receives `{ context, resource }`
 - variant (`string`, optional): Button visual style, defaults to `'primary'`
   - Supported values: `'accent'`, `'primary'`, `'secondary'`, `'negative'`
 
@@ -346,15 +346,15 @@ headerMenu: {
 
 `getHiddenHeaderButtonIds({ context, resource })`
 
-**Description:** Returns an array of [built-in header button ids](#built-in-header-buttons) that should be hidden.
+**Description:** Returns an array of [built-in header menu button ids](#built-in-header-menu-buttons) that should be hidden.
 
-The host calls this method when the browse location or context changes. Extension code should return quickly; avoid slow or blocking work (for example backend calls), because the host may wait on the result before rendering header buttons.
+The host calls this method when the browse location or context changes. Extension code should return quickly; avoid slow or blocking work (for example backend calls), because the host may wait on the result before rendering header menu buttons.
 
 **Parameters:**
 - context (`string`): current [browsing context](#browsing-context).
 - resource (`object`): Same semantics as for [`getButtons`](#headermenu-namespace).
 
-**Returns:** (`array`) An array of built-in header button ids to hide, or an empty array if none should be hidden.
+**Returns:** (`array`) An array of built-in header menu button ids to hide, or an empty array if none should be hidden.
 
 **Example:**
 
@@ -369,10 +369,10 @@ getHiddenHeaderButtonIds: ({ context, resource }) => {
 
 `overrideHeaderMenuButton({ buttonId, context, resource })`
 
-**Description:** Return `true` if the extension handled the click and the built-in header button handler should **not** run. Return `false` to let the Host run the default behavior.
+**Description:** Return `true` if the extension handled the click and the built-in header menu button handler should **not** run. Return `false` to let the Host run the default behavior.
 
 **Parameters:**
-- buttonId (`string`): Built-in header button id from [Built-in header buttons](#built-in-header-buttons).
+- buttonId (`string`): Built-in header menu button id from [Built-in header menu buttons](#built-in-header-menu-buttons).
 - context (`string`): current [browsing context](#browsing-context).
 - resource (`object`): Same semantics as for [`getButtons`](#headermenu-namespace).
 
@@ -393,9 +393,9 @@ overrideHeaderMenuButton: ({ buttonId, context, resource }) => {
 
 ## Examples
 
-These code snippets demonstrate how to add a custom action to the ActionBar, add header buttons to the HeaderMenu,
+These code snippets demonstrate how to add a custom action to the ActionBar, add buttons to the header menu,
 hide built-in actions or override built-in action handlers from the ActionBar and QuickActions menu, and optionally
-hide or override built-in header buttons in the Browse View. (The examples below serve illustrative purposes thus omit
+hide or override built-in header menu buttons in the Browse View. (The examples below serve illustrative purposes thus omit
 certain import statements and other non-important parts.)
 
 The ExtensionRegistration component initializes the extension registration process by calling the `register()` function
@@ -678,9 +678,9 @@ function ExtensionRegistration() {
 }
 ```
 
-### Example of hiding built-in header buttons
+### Example of hiding built-in header menu buttons
 
-In this example, the built-in **Create folder** header button (`createFolder`) is hidden in the `assets` context.
+In this example, the built-in **Create folder** header menu button (`createFolder`) is hidden in the `assets` context.
 
 ```js
 function ExtensionRegistration() {
@@ -716,9 +716,9 @@ function ExtensionRegistration() {
 export default ExtensionRegistration;
 ```
 
-### Example of overriding a built-in header button
+### Example of overriding a built-in header menu button
 
-In this example, when the user activates the **Add assets** header button (`addAssets`), the extension runs custom logic
+In this example, when the user activates the **Add assets** header menu button (`addAssets`), the extension runs custom logic
 and skips the Host's default handler by returning `true`.
 
 ```js
@@ -756,6 +756,6 @@ function ExtensionRegistration() {
 export default ExtensionRegistration;
 ```
 
-To open a custom dialog from custom ActionBar actions, QuickActions menu actions or HeaderMenu header buttons, refer to the
+To open a custom dialog from custom ActionBar actions, QuickActions menu actions, or header menu buttons, refer to the
 [Modal API](../commons/index.md#modal-api) provided by AEM Assets View to all extensions for implementation of
 dialog management.

--- a/src/pages/services/aem-assets-view/api/browse-view/index.md
+++ b/src/pages/services/aem-assets-view/api/browse-view/index.md
@@ -107,8 +107,8 @@ action ids of actions that can be hidden:
 
 #### Built-in header buttons
 
-Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar.
-Depending on context and extension point, the host exposes the following built-in header **button** ids that can be hidden or overridden.
+Browse extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header buttons in the top bar.
+Depending on context and extension point, the host exposes the following built-in header button ids that can be hidden or overridden.
 
 | Context |  Header button IDs that can be hidden or overridden |
 |------------|------------|
@@ -285,7 +285,7 @@ overrideBuiltInAction: ({ actionId, context, resource }) => {
 
 #### headerMenu namespace
 
-The `headerMenu` namespace supports custom **header buttons** in the browse header and optional customization of built-in header buttons.
+The `headerMenu` namespace supports adding custom header buttons in the browse header and optionally hiding and overriding of built-in header buttons.
 
 If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
 

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -261,7 +261,7 @@ function ExtensionRegistration() {
 export default ExtensionRegistration;
 ```
 
-To hide or override built-in header buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, to hide the built-in **Download** header button:
+To hide or override built-in header buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, hide the built-in **Download** header button and take over the **Assign tasks** click (skipping the Host handler when you return `true`):
 
 ```js
 headerMenu: {
@@ -270,6 +270,13 @@ headerMenu: {
     },
     async getHiddenHeaderButtonIds({ context, resource }) {
         return ['download'];
+    },
+    async overrideHeaderMenuButton({ buttonId, context, resource }) {
+        if (buttonId === 'assignTasks') {
+            // Custom assign-tasks flow; skip built-in handler
+            return true;
+        }
+        return false;
     },
 },
 ```

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -24,12 +24,12 @@ Extensions should use the `aem/assets/details/1` extension point to utilize exte
 
 ## Custom header buttons in Details View
 
-The top header on the Details View exposes **header buttons** (for example **Assign tasks** and **Download**) that are separate from the ActionBar and QuickActions on browse screens.
+The top header on the Details View exposes header buttons (for example "Assign tasks" and "Download").
 
 Using the optional [`headerMenu`](#headermenu-namespace) namespace, a details extension can add custom header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not run.
 If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
 
-Built-in header button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header buttons](../browse-view/index.md#built-in-header-buttons) table (`details` row).
+Built-in header button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header buttons](#built-in-header-buttons) table below.
 
 ## Custom side panels
 
@@ -96,8 +96,8 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 
 #### Built-in header buttons
 
-Details extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar.
-The host exposes the following built-in header **button** ids that can be hidden or overridden.
+Details extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header buttons in the top bar.
+The host exposes the following built-in header button ids that can be hidden or overridden.
 
 | Context |  Header button IDs that can be hidden or overridden |
 |------------|------------|
@@ -105,7 +105,7 @@ The host exposes the following built-in header **button** ids that can be hidden
 
 #### headerMenu namespace
 
-The `headerMenu` namespace supports custom **header buttons** in the Details View header and optional customization of built-in header buttons there.
+The `headerMenu` namespace supports adding custom **header buttons** in the Details View header and optionally hiding and overriding of built-in header buttons there.
 
 If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
 
@@ -117,13 +117,46 @@ If you declare `headerMenu`, you **must** implement `getButtons`. You may also i
 
 `getButtons({ context, resource })`
 
-**Description:** Returns an array of custom header button definitions for the Details View header, using the same descriptor shape as [`getButtons` in the Browse View `headerMenu` namespace](../browse-view/index.md#headermenu-namespace).
+**Description:** Returns an array of custom header button definitions that will be added to the Details View header. These header buttons are rendered alongside built-in header buttons and let extensions surface actions in the top header while viewing an asset or folder.
 
-**Returns:** (`array`) An array of button configuration objects (see Browse View headerMenu for property list).
+**Parameters:**
+- context (`string`): Current context for the Details View, as communicated by the Host.
+- resource (`object`): The asset or folder currently shown in the Details View.
+  - id (`string`): Resource URN.
+  - path (`string`): Resource path.
+  - Matches the object returned by [`details.getCurrentResourceInfo()`](#host-api-reference).
+
+**Returns:** (`array`) An array of button configuration objects. Each object contains:
+- id (`string`): Unique identifier for the button within the extension
+- label (`string`): Display text for the button
+- icon (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons)
+- onClick (`function`): Callback when the header button is clicked; receives `{ context, resource }`
+- variant (`string`, optional): Button visual style, defaults to `'primary'`
+  - Supported values: `'accent'`, `'primary'`, `'secondary'`, `'negative'`
+
+**Example:**
+
+```javascript
+headerMenu: {
+  async getButtons({ context, resource }) {
+    return [
+      {
+        id: 'details-export',
+        label: 'Export',
+        icon: 'Download',
+        variant: 'secondary',
+        onClick: async ({ context, resource }) => {
+          // resource is the asset or folder open in Details View
+        },
+      },
+    ];
+  },
+},
+```
 
 `getHiddenHeaderButtonIds({ context, resource })`
 
-**Description:** Returns an array of built-in header button ids to hide in the Details View. See the `details` row under [Built-in header buttons](../browse-view/index.md#built-in-header-buttons) (`assignTasks`, `download`).
+**Description:** Returns an array of built-in header button ids to hide in the Details View. For this extension point the ids are `assignTasks` and `download` (see [Built-in header buttons](#built-in-header-buttons)).
 
 The host calls this method when the asset or context relevant to the header changes. Return quickly; avoid slow or blocking work while the host resolves header button visibility.
 
@@ -134,7 +167,7 @@ The host calls this method when the asset or context relevant to the header chan
 **Description:** Return `true` if the extension handled the click and the built-in header button handler should **not** run. Return `false` to let the Host run the default behavior.
 
 **Parameters:**
-- buttonId (`string`): Built-in header button id (`assignTasks` or `download` for Details View; see [Built-in header buttons](../browse-view/index.md#built-in-header-buttons)).
+- buttonId (`string`): Built-in header button id for Details View: `assignTasks` or `download` (see [Built-in header buttons](#built-in-header-buttons)).
 
 **Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
 

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -22,14 +22,14 @@ You can provide documentation feedback by clicking "Log an issue".
 
 Extensions should use the `aem/assets/details/1` extension point to utilize extensibility services of the Details View.
 
-## Custom header buttons in Details View
+## Custom header menu buttons in Details View
 
-The top header on the Details View exposes header buttons (for example "Assign tasks" and "Download").
+The Details View header menu includes built-in buttons (for example "Assign tasks" and "Download").
 
-Using the optional [`headerMenu`](#headermenu-namespace) namespace, a details extension can add custom header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not run.
+Using the optional [`headerMenu`](#headermenu-namespace) namespace, a details extension can add custom header menu buttons, hide built-in header menu buttons by id (removing them from the header menu), and override built-in header menu button clicks so the default handler does not run.
 If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
 
-Built-in header button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header buttons](#built-in-header-buttons) table below.
+Built-in header menu button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header menu buttons](#built-in-header-menu-buttons) table below.
 
 ## Custom side panels
 
@@ -94,18 +94,18 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 - `contentUrl` (`string`): Relative root to the panel's content.
 - `reloadOnThemeChange` (`boolean`): Whether to reload custom panel when application theme changes.
 
-#### Built-in header buttons
+#### Built-in header menu buttons
 
-Details extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header buttons in the top bar.
-The host exposes the following built-in header button ids that can be hidden or overridden.
+Details extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize header menu buttons in the top bar.
+The host exposes the following built-in header menu button ids that can be hidden or overridden.
 
-| Context |  Header button IDs that can be hidden or overridden |
+| Context | Header menu button IDs that can be hidden or overridden |
 |------------|------------|
 | `details` | "assignTasks", "download" |
 
 #### headerMenu namespace
 
-The `headerMenu` namespace supports adding custom **header buttons** in the Details View header and optionally hiding and overriding of built-in header buttons there.
+The `headerMenu` namespace supports adding custom **header menu buttons** in the Details View header menu and optionally hiding and overriding built-in header menu buttons there.
 
 If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
 
@@ -117,7 +117,7 @@ If you declare `headerMenu`, you **must** implement `getButtons`. You may also i
 
 `getButtons({ context, resource })`
 
-**Description:** Returns an array of custom header button definitions that will be added to the Details View header. These header buttons are rendered alongside built-in header buttons and let extensions surface actions in the top header while viewing an asset or folder.
+**Description:** Returns an array of custom header menu button definitions that will be added to the Details View header menu. These buttons are rendered alongside built-in header menu buttons and let extensions surface actions in the header menu while viewing an asset or folder.
 
 **Parameters:**
 - context (`string`): Current context for the Details View, as communicated by the Host.
@@ -130,7 +130,7 @@ If you declare `headerMenu`, you **must** implement `getButtons`. You may also i
 - id (`string`): Unique identifier for the button within the extension
 - label (`string`): Display text for the button
 - icon (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons)
-- onClick (`function`): Callback when the header button is clicked; receives `{ context, resource }`
+- onClick (`function`): Callback when the header menu button is clicked; receives `{ context, resource }`
 - variant (`string`, optional): Button visual style, defaults to `'primary'`
   - Supported values: `'accent'`, `'primary'`, `'secondary'`, `'negative'`
 
@@ -156,18 +156,18 @@ headerMenu: {
 
 `getHiddenHeaderButtonIds({ context, resource })`
 
-**Description:** Returns an array of built-in header button ids to hide in the Details View. For this extension point the ids are `assignTasks` and `download` (see [Built-in header buttons](#built-in-header-buttons)).
+**Description:** Returns an array of built-in header menu button ids to hide in the Details View. For this extension point the ids are `assignTasks` and `download` (see [Built-in header menu buttons](#built-in-header-menu-buttons)).
 
-The host calls this method when the asset or context relevant to the header changes. Return quickly; avoid slow or blocking work while the host resolves header button visibility.
+The host calls this method when the asset or context relevant to the header menu changes. Return quickly; avoid slow or blocking work while the host resolves header menu button visibility.
 
-**Returns:** (`array`) An array of built-in header button ids to hide, or an empty array if none should be hidden.
+**Returns:** (`array`) An array of built-in header menu button ids to hide, or an empty array if none should be hidden.
 
 `overrideHeaderMenuButton({ buttonId, context, resource })`
 
-**Description:** Return `true` if the extension handled the click and the built-in header button handler should **not** run. Return `false` to let the Host run the default behavior.
+**Description:** Return `true` if the extension handled the click and the built-in header menu button handler should **not** run. Return `false` to let the Host run the default behavior.
 
 **Parameters:**
-- buttonId (`string`): Built-in header button id for Details View: `assignTasks` or `download` (see [Built-in header buttons](#built-in-header-buttons)).
+- buttonId (`string`): Built-in header menu button id for Details View: `assignTasks` or `download` (see [Built-in header menu buttons](#built-in-header-menu-buttons)).
 
 **Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
 
@@ -261,7 +261,7 @@ function ExtensionRegistration() {
 export default ExtensionRegistration;
 ```
 
-To hide or override built-in header buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, hide the built-in **Download** header button and take over the **Assign tasks** click (skipping the Host handler when you return `true`):
+To hide or override built-in header menu buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, hide the built-in **Download** header menu button and take over the **Assign tasks** click (skipping the Host handler when you return `true`):
 
 ```js
 headerMenu: {

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -107,6 +107,8 @@ The host exposes the following built-in header menu button ids that can be hidde
 
 The `headerMenu` namespace supports adding custom **header menu buttons** in the Details View header menu and optionally hiding and overriding built-in header menu buttons there.
 
+`headerMenu` behavior is shared between Browse View and Details View. If an extension implements `headerMenu` in either `aem/assets/browse/1` or `aem/assets/details/1`, those methods are used for header menu handling in both screens. The built-in button set and button ids still differ by screen/context, so use the appropriate ids from each page's [Built-in header menu buttons](#built-in-header-menu-buttons) table.
+
 All `headerMenu` methods are optional:
 
 - `getButtons({ context, resource })` — optional

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -94,6 +94,15 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 - `contentUrl` (`string`): Relative root to the panel's content.
 - `reloadOnThemeChange` (`boolean`): Whether to reload custom panel when application theme changes.
 
+#### Built-in header buttons
+
+Details extensions use the [`headerMenu`](#headermenu-namespace) namespace to customize **header buttons** in the top bar.
+The host exposes the following built-in header **button** ids that can be hidden or overridden.
+
+| Context |  Header button IDs that can be hidden or overridden |
+|------------|------------|
+| `details` | "assignTasks", "download" |
+
 #### headerMenu namespace
 
 The `headerMenu` namespace supports custom **header buttons** in the Details View header and optional customization of built-in header buttons there.
@@ -128,6 +137,8 @@ The host calls this method when the asset or context relevant to the header chan
 - buttonId (`string`): Built-in header button id (`assignTasks` or `download` for Details View; see [Built-in header buttons](../browse-view/index.md#built-in-header-buttons)).
 
 **Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
+
+
 
 ## Example of adding custom side panels
 

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -27,7 +27,7 @@ Extensions should use the `aem/assets/details/1` extension point to utilize exte
 The Details View header menu includes built-in buttons (for example "Assign tasks" and "Download").
 
 Using the optional [`headerMenu`](#headermenu-namespace) namespace, a details extension can add custom header menu buttons, hide built-in header menu buttons by id (removing them from the header menu), and override built-in header menu button clicks so the default handler does not run.
-If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
+If you implement `headerMenu`, all of its methods are optional: `getButtons`, `getHiddenButtonIds`, and `overrideButton`. Implement only the methods your extension needs.
 
 Built-in header menu button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header menu buttons](#built-in-header-menu-buttons) table below.
 
@@ -107,11 +107,13 @@ The host exposes the following built-in header menu button ids that can be hidde
 
 The `headerMenu` namespace supports adding custom **header menu buttons** in the Details View header menu and optionally hiding and overriding built-in header menu buttons there.
 
-If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
+All `headerMenu` methods are optional:
 
-- `getButtons({ context, resource })` — **required** when `headerMenu` is present
-- `getHiddenHeaderButtonIds({ context, resource })` — optional
-- `overrideHeaderMenuButton({ buttonId, context, resource })` — optional
+- `getButtons({ context, resource })` — optional
+- `getHiddenButtonIds({ context, resource })` — optional
+- `overrideButton({ buttonId, context, resource })` — optional
+
+For example, you can implement only `getHiddenButtonIds` or `overrideButton` without implementing `getButtons`.
 
 `resource` describes the asset or folder currently shown in the Details View (see [`details.getCurrentResourceInfo()`](#host-api-reference)).
 
@@ -154,7 +156,7 @@ headerMenu: {
 },
 ```
 
-`getHiddenHeaderButtonIds({ context, resource })`
+`getHiddenButtonIds({ context, resource })`
 
 **Description:** Returns an array of built-in header menu button ids to hide in the Details View. For this extension point the ids are `assignTasks` and `download` (see [Built-in header menu buttons](#built-in-header-menu-buttons)).
 
@@ -162,7 +164,7 @@ The host calls this method when the asset or context relevant to the header menu
 
 **Returns:** (`array`) An array of built-in header menu button ids to hide, or an empty array if none should be hidden.
 
-`overrideHeaderMenuButton({ buttonId, context, resource })`
+`overrideButton({ buttonId, context, resource })`
 
 **Description:** Return `true` if the extension handled the click and the built-in header menu button handler should **not** run. Return `false` to let the Host run the default behavior.
 
@@ -223,7 +225,7 @@ provided by the `@adobe/uix-guest` library.
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares that the
 extension uses the `detailSidePanel` namespace and its `getPanels` method, and may include the optional `headerMenu` namespace.
-For `headerMenu`, only `getButtons` is required if you add that namespace.
+For `headerMenu`, all methods are optional; this example stubs out `getButtons`, `getHiddenButtonIds`, and `overrideButton`.
 
 ```js
 function ExtensionRegistration() {
@@ -249,6 +251,12 @@ function ExtensionRegistration() {
                     async getButtons({ context, resource }) {
                         return [];
                     },
+                    async getHiddenButtonIds({ context, resource }) {
+                        return [];
+                    },
+                    async overrideButton({ buttonId, context, resource }) {
+                        return false;
+                    },
                 },
             },
         });
@@ -261,17 +269,17 @@ function ExtensionRegistration() {
 export default ExtensionRegistration;
 ```
 
-To hide or override built-in header menu buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, hide the built-in **Download** header menu button and take over the **Assign tasks** click (skipping the Host handler when you return `true`):
+To hide or override built-in header menu buttons in the Details View, add `getHiddenButtonIds` and/or `overrideButton` (and `getButtons` if you add custom buttons). For example, hide the built-in **Download** header menu button and take over the **Assign tasks** click (skipping the Host handler when you return `true`):
 
 ```js
 headerMenu: {
     async getButtons({ context, resource }) {
         return [];
     },
-    async getHiddenHeaderButtonIds({ context, resource }) {
+    async getHiddenButtonIds({ context, resource }) {
         return ['download'];
     },
-    async overrideHeaderMenuButton({ buttonId, context, resource }) {
+    async overrideButton({ buttonId, context, resource }) {
         if (buttonId === 'assignTasks') {
             // Custom assign-tasks flow; skip built-in handler
             return true;

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -160,7 +160,7 @@ headerMenu: {
 
 `getHiddenButtonIds({ context, resource })`
 
-**Description:** Returns an array of built-in header menu button ids to hide in the Details View. For this extension point the ids are `assignTasks` and `download` (see [Built-in header menu buttons](#built-in-header-menu-buttons)).
+**Description:** Returns an array of built-in header menu button ids to hide in the Details View. Supported ids are those listed for the `details` context in [Built-in header menu buttons](#built-in-header-menu-buttons).
 
 The host calls this method when the asset or context relevant to the header menu changes. Return quickly; avoid slow or blocking work while the host resolves header menu button visibility.
 
@@ -171,7 +171,7 @@ The host calls this method when the asset or context relevant to the header menu
 **Description:** Return `true` if the extension handled the click and the built-in header menu button handler should **not** run. Return `false` to let the Host run the default behavior.
 
 **Parameters:**
-- buttonId (`string`): Built-in header menu button id for Details View: `assignTasks` or `download` (see [Built-in header menu buttons](#built-in-header-menu-buttons)).
+- buttonId (`string`): Built-in header menu button id for the Details View; must be one of the ids listed for the `details` context in [Built-in header menu buttons](#built-in-header-menu-buttons).
 
 **Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
 

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -22,6 +22,15 @@ You can provide documentation feedback by clicking "Log an issue".
 
 Extensions should use the `aem/assets/details/1` extension point to utilize extensibility services of the Details View.
 
+## Custom header buttons in Details View
+
+The top header on the Details View exposes **header buttons** (for example **Assign tasks** and **Download**) that are separate from the ActionBar and QuickActions on browse screens.
+
+Using the optional [`headerMenu`](#headermenu-namespace) namespace, a details extension can add custom header buttons, hide built-in header buttons by id (removing them from the header), and override built-in header button clicks so the default handler does not run.
+If you implement `headerMenu`, the only required method is `getButtons`; `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton` are optional.
+
+Built-in header button ids for the Details View (`aem/assets/details/1`) are listed in the [Built-in header buttons](../browse-view/index.md#built-in-header-buttons) table (`details` row).
+
 ## Custom side panels
 
 The extensibility feature allows adding new panels and corresponding icon buttons to the side rail 
@@ -44,9 +53,9 @@ to the extension and the API provided by the extension to the AEM Assets View ho
 
 ### Host API Reference
 
-In addition to the [Common API](../commons/index.md) provided by AEM Assets View to all extensions, 
-the host application provides the following API specific to the `aem/assets/details/1` extension point 
-and the [`detailSidePanel`](#detailsidepanel-namespace) namespace.
+In addition to the [Common API](../commons/index.md) provided by AEM Assets View to all extensions,
+the host application provides the following API specific to the `aem/assets/details/1` extension point,
+the [`detailSidePanel`](#detailsidepanel-namespace) namespace, and the optional [`headerMenu`](#headermenu-namespace) namespace.
 
 `details.getCurrentResourceInfo()`
 
@@ -63,7 +72,7 @@ const { path, id } = await guestConnection.host.details.getCurrentResourceInfo()
 
 ### Extension API Reference
 
-The extension definition object passed by the extension to the `register()` function defines the [`detailSidePanel`](#detailsidepanel-namespace) namespace.
+The extension definition object passed by the extension to the `register()` function defines the [`detailSidePanel`](#detailsidepanel-namespace) namespace and may optionally define the [`headerMenu`](#headermenu-namespace) namespace.
 
 #### detailSidePanel namespace
 
@@ -84,6 +93,41 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 - `icon` (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons).
 - `contentUrl` (`string`): Relative root to the panel's content.
 - `reloadOnThemeChange` (`boolean`): Whether to reload custom panel when application theme changes.
+
+#### headerMenu namespace
+
+The `headerMenu` namespace supports custom **header buttons** in the Details View header and optional customization of built-in header buttons there.
+
+If you declare `headerMenu`, you **must** implement `getButtons`. You may also implement `getHiddenHeaderButtonIds` and `overrideHeaderMenuButton`.
+
+- `getButtons({ context, resource })` — **required** when `headerMenu` is present
+- `getHiddenHeaderButtonIds({ context, resource })` — optional
+- `overrideHeaderMenuButton({ buttonId, context, resource })` — optional
+
+`resource` describes the asset or folder currently shown in the Details View (see [`details.getCurrentResourceInfo()`](#host-api-reference)).
+
+`getButtons({ context, resource })`
+
+**Description:** Returns an array of custom header button definitions for the Details View header, using the same descriptor shape as [`getButtons` in the Browse View `headerMenu` namespace](../browse-view/index.md#headermenu-namespace).
+
+**Returns:** (`array`) An array of button configuration objects (see Browse View headerMenu for property list).
+
+`getHiddenHeaderButtonIds({ context, resource })`
+
+**Description:** Returns an array of built-in header button ids to hide in the Details View. See the `details` row under [Built-in header buttons](../browse-view/index.md#built-in-header-buttons) (`assignTasks`, `download`).
+
+The host calls this method when the asset or context relevant to the header changes. Return quickly; avoid slow or blocking work while the host resolves header button visibility.
+
+**Returns:** (`array`) An array of built-in header button ids to hide, or an empty array if none should be hidden.
+
+`overrideHeaderMenuButton({ buttonId, context, resource })`
+
+**Description:** Return `true` if the extension handled the click and the built-in header button handler should **not** run. Return `false` to let the Host run the default behavior.
+
+**Parameters:**
+- buttonId (`string`): Built-in header button id (`assignTasks` or `download` for Details View; see [Built-in header buttons](../browse-view/index.md#built-in-header-buttons)).
+
+**Returns:** (`boolean`) `false` for the Host to use the built-in handler, `true` to skip the built-in handler.
 
 ## Example of adding custom side panels
 
@@ -134,8 +178,8 @@ The `ExtensionRegistration` component initializes the extension registration pro
 provided by the `@adobe/uix-guest` library. 
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares that the
-extension uses the `detailSidePanel` namespace and declares `getPanels` method which returns an array of custom panels.
-The custom panel, among other properties, specifies the icon's tooltip, the custom panel title and the route to the panel content.
+extension uses the `detailSidePanel` namespace and its `getPanels` method, and may include the optional `headerMenu` namespace.
+For `headerMenu`, only `getButtons` is required if you add that namespace.
 
 ```js
 function ExtensionRegistration() {
@@ -157,6 +201,11 @@ function ExtensionRegistration() {
                         ];
                     },
                 },
+                headerMenu: {
+                    async getButtons({ context, resource }) {
+                        return [];
+                    },
+                },
             },
         });
     };
@@ -166,6 +215,19 @@ function ExtensionRegistration() {
 }
 
 export default ExtensionRegistration;
+```
+
+To hide or override built-in header buttons in the Details View, add the optional `getHiddenHeaderButtonIds` or `overrideHeaderMenuButton` methods alongside `getButtons`. For example, to hide the built-in **Download** header button:
+
+```js
+headerMenu: {
+    async getButtons({ context, resource }) {
+        return [];
+    },
+    async getHiddenHeaderButtonIds({ context, resource }) {
+        return ['download'];
+    },
+},
 ```
 
 The `PanelExtensionTemplate` component is responsible for rendering the custom panel content. It uses the `attach()` function


### PR DESCRIPTION
Update docs for header menu button phase 2 (only merge after GA)


## Description
Update docs for `headerMenu` extensions that
- Add custom button to the Header menu in **detail** extension
- Hide buttons in the Header menu in detail extension
- Override buttons in the Header menu in detail extension
- Hide buttons in the Header menu in browse extension
- Override buttons in the Header menu in browse extension

## Related Issue
https://github.com/AdobeDocs/uix/issues/149
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
