### PR TITLE
ASSETS-66260 Update detailSidePanel docs (Merge after GA) 

### DIFF
--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -128,7 +128,7 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 
 ##### detailSidePanel.overrideBuiltInPanel()
 
-**Description:** for a single built-in panel, return replacement content hosted by the extension, or `null` to keep the default implementation. The host calls this when the user selects a built-in rail button whose panel is eligible for override. 
+**Description:** Return replacement content hosted by the extension, or `null` to keep the default implementation. The host calls this when the user selects a built-in rail button whose panel is eligible for override. 
 
 **Parameters**
 
@@ -196,7 +196,7 @@ The `ExtensionRegistration` component initializes the extension registration pro
 provided by the `@adobe/uix-guest` library. 
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares that the
-extension uses the `detailSidePanel` namespace and implements `getPanels` (and optionally `getHiddenBuiltInPanels` and `overrideBuiltInPanel`). 
+extension uses the `detailSidePanel` namespace and implements at least one of the following: `getPanels`, `getHiddenBuiltInPanels` or `overrideBuiltInPanel`. 
 The custom panel objects returned by `getPanels`, specifies the icon's tooltip, the custom panel title and the route to the panel content.
 
 ```js
@@ -218,11 +218,9 @@ function ExtensionRegistration() {
                             },
                         ];
                     },
-                    // Optional: only used when the host supports hiding built-in panels
                     getHiddenBuiltInPanels({ resource }) {
                         return ['dynamicmedia', 'comment'];
                     },
-                    // Optional: only used when the host supports overriding built-in panel content
                     overrideBuiltInPanel({ panelId, resource }) {
                         if (panelId === 'renditions') {
                             return {

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -25,8 +25,8 @@ Extensions should use the `aem/assets/details/1` extension point to utilize exte
 ## Custom side panels
 
 The extensibility feature allows adding new panels and corresponding icon buttons to the side rail 
-using the [`detailSidePanel`](#detailsidepanel-namespace) namespace. The custom icons appear under the 
-list of the standard panel icons.
+using the [`getPanels`](#detailsidepanelgetpanels) method from the [`detailSidePanel`](#detailsidepanel-namespace) namespace. The custom icons appear under the 
+list of the built-in panel icons.
 
 ![](side-panel.png)
 
@@ -36,6 +36,26 @@ deep linking panel in the URL and auto-hiding the panel when an asset changes.
 The host is also responsible for rendering panel's header.
 
 The extension only declares the icon type, panel title and the URL for the custom panel content.
+
+### Hiding and overriding built-in panels
+
+AEM Assets View supports built-in panel customization:
+
+- **Hide** selected built-in panels by returning their IDs from [`getHiddenBuiltInPanels`](#detailsidepanelgethiddenbuiltinpanels).
+- **Replace** the body of a built-in panel with extension-hosted content by implementing [`overrideBuiltInPanel`](#detailsidepaneloverridebuiltinpanel). The built-in icon and rail entry stay; only the panel content is swapped for your `contentUrl`.
+
+Methods may return a Promise or a plain value; the host awaits them.
+
+#### Built-in panel IDs
+
+The host application allows hiding and overriding only certain built-in panels. Depending on what is open in the Details View, below is the list of panel IDs that are honored for [`getHiddenBuiltInPanels`](#detailsidepanelgethiddenbuiltinpanels) and [`overrideBuiltInPanel`](#detailsidepaneloverridebuiltinpanel). Any other ID is ignored.
+
+| Details context | Panel IDs that can be hidden or overridden |
+|------------|------------|
+| `asset-details` (file asset) | "comment", "edit", "renditions", "tasks", "version", "dynamicmedia", "assetRelations", "watchedAssets" |
+| `folder-details` | "watchedAssets" |
+| `collection-details` | "watchedAssets" |
+
 
 ## API Reference
 
@@ -67,15 +87,24 @@ The extension definition object passed by the extension to the `register()` func
 
 #### detailSidePanel namespace
 
-The `detailSidePanel` namespace includes the following method:
-- `getPanels()`
+The `detailSidePanel` namespace can implement the following methods:
 
-`detailSidePanel.getPanels()`
+- [`getPanels`](#detailsidepanelgetpanels) — required
+- [`getHiddenBuiltInPanels`](#detailsidepanelgethiddenbuiltinpanels) — optional 
+- [`overrideBuiltInPanel`](#detailsidepaneloverridebuiltinpanel) — optional
+
+##### detailSidePanel.getPanels()
 
 **Description:** returns an array of custom panel descriptors that the extension wants to add to the side rail 
 of the Details View.
 
-**Returns** (`array`) an array of custom panel descriptors or an empty array if no custom panels should be added.
+**Parameters**
+
+- `resource` (`object`): Current asset context.
+  - `id` (`string`): Current asset id.
+  - `path` (`string`): Current asset path.
+
+**Returns** (`array` or `Promise<array>`) an array of custom panel descriptors or an empty array if no custom panels should be added.
 
 Each array element is a custom panel descriptor that is a JSON with the following properties:
 - `id` (`string`): Panel id, unique within given extension.
@@ -84,6 +113,39 @@ Each array element is a custom panel descriptor that is a JSON with the followin
 - `icon` (`string`): Name of the [React-Spectrum workflow icon](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html#available-icons).
 - `contentUrl` (`string`): Relative root to the panel's content.
 - `reloadOnThemeChange` (`boolean`): Whether to reload custom panel when application theme changes.
+
+##### detailSidePanel.getHiddenBuiltInPanels()
+
+**Description:** returns an array of built-in panel IDs that this extension wants removed from the Details side rail for the current asset.
+
+**Parameters**
+
+- `resource` (`object`): Current asset context.
+  - `id` (`string`): Current asset id.
+  - `path` (`string`): Current asset path.
+
+**Returns** (`array` of `string` or `Promise<array>`): Panel IDs to hide. IDs that are not on the host allowlist are ignored.
+
+##### detailSidePanel.overrideBuiltInPanel()
+
+**Description:** for a single built-in panel, return replacement content hosted by the extension, or `null` to keep the default implementation. The host calls this when the user selects a built-in rail button whose panel is eligible for override. 
+
+**Parameters**
+
+- `panelId` (`string`): Built-in panel ID (one of the allowlisted IDs).
+- `resource` (`object`): Current asset context.
+  - `id` (`string`): Current asset id.
+  - `path` (`string`): Current asset path.
+
+**Returns** (`object`, `null`, or `Promise`):
+
+- Return `null` to use the built-in panel content.
+- To override, return an object with:
+  - `contentUrl` (`string`, required): URL for the replacement panel body (same pattern as custom panels).
+  - `reloadOnThemeChange` (`boolean`, optional): Reload iframe on theme change when `true`. Defaults to `false`.
+  - `title` (`string`, optional): Non-empty string replaces the sets panel header title for this override. Otherwise title is not shown on overridden panels. 
+
+The built-in **icon, tooltip, and rail button** are unchanged; only **title** (optional) and **panel body** come from the extension when an override applies.
 
 ## Example of adding custom side panels
 
@@ -134,8 +196,8 @@ The `ExtensionRegistration` component initializes the extension registration pro
 provided by the `@adobe/uix-guest` library. 
 
 The objects passed to the `register()` function describe the extension and its capabilities. In particular, it declares that the
-extension uses the `detailSidePanel` namespace and declares `getPanels` method which returns an array of custom panels.
-The custom panel, among other properties, specifies the icon's tooltip, the custom panel title and the route to the panel content.
+extension uses the `detailSidePanel` namespace and implements `getPanels` (and optionally `getHiddenBuiltInPanels` and `overrideBuiltInPanel`). 
+The custom panel objects returned by `getPanels`, specifies the icon's tooltip, the custom panel title and the route to the panel content.
 
 ```js
 function ExtensionRegistration() {
@@ -144,17 +206,32 @@ function ExtensionRegistration() {
             id: extensionId,
             methods: {
                 detailSidePanel: {
-                    getPanels() {
+                    getPanels({ resource }) {
                         return [
                             {
-                                'id': 'extension-template',
-                                'tooltip': 'Extension Template',
-                                'icon': 'Extension',
-                                'title': 'Extension Template',
-                                'contentUrl': '/#extension-template',
-                                'reloadOnThemeChange': 'true',
+                                id: 'extension-template',
+                                tooltip: 'Extension Template',
+                                icon: 'Extension',
+                                title: 'Extension Template',
+                                contentUrl: '/#extension-template',
+                                reloadOnThemeChange: true,
                             },
                         ];
+                    },
+                    // Optional: only used when the host supports hiding built-in panels
+                    getHiddenBuiltInPanels({ resource }) {
+                        return ['dynamicmedia', 'comment'];
+                    },
+                    // Optional: only used when the host supports overriding built-in panel content
+                    overrideBuiltInPanel({ panelId, resource }) {
+                        if (panelId === 'renditions') {
+                            return {
+                                contentUrl: '/#custom-renditions',
+                                reloadOnThemeChange: true,
+                                title: 'Custom renditions',
+                            };
+                        }
+                        return null;
                     },
                 },
             },

--- a/src/pages/services/aem-assets-view/api/details-view/index.md
+++ b/src/pages/services/aem-assets-view/api/details-view/index.md
@@ -89,9 +89,9 @@ The extension definition object passed by the extension to the `register()` func
 
 The `detailSidePanel` namespace can implement the following methods:
 
-- [`getPanels`](#detailsidepanelgetpanels) — required
-- [`getHiddenBuiltInPanels`](#detailsidepanelgethiddenbuiltinpanels) — optional 
-- [`overrideBuiltInPanel`](#detailsidepaneloverridebuiltinpanel) — optional
+- [`getPanels`](#detailsidepanelgetpanels) 
+- [`getHiddenBuiltInPanels`](#detailsidepanelgethiddenbuiltinpanels) 
+- [`overrideBuiltInPanel`](#detailsidepaneloverridebuiltinpanel) 
 
 ##### detailSidePanel.getPanels()
 


### PR DESCRIPTION
Updated docs for details side panel with getHiddenBuiltInPanels and overrideBuiltInPanel details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated Assets View Details UIX docs with added methods for `detailSidePanel` namespace

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Keeps the docs current with the the latest API capabilities 
<!--- Why is this change required? What problem does it solve? -->
